### PR TITLE
libgit2: update to v1.4.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libgit2"]
 	path = libgit2
-	url = https://github.com/dogged/libgit2
+	url = https://github.com/libgit2/libgit2


### PR DESCRIPTION
Update to [libgit2 v1.4.0](https://github.com/libgit2/libgit2/releases/v1.4.0).